### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/zifanyaofr/c0b34ee7-1de7-4248-aeb8-3cd0e07192ca/ce827fa1-a338-49e9-bec3-ef9b0c0d031d/_apis/work/boardbadge/5232d6d3-5203-4a32-ad28-9e4655cdf0e0)](https://dev.azure.com/zifanyaofr/c0b34ee7-1de7-4248-aeb8-3cd0e07192ca/_boards/board/t/ce827fa1-a338-49e9-bec3-ef9b0c0d031d/Microsoft.RequirementCategory)
 # gabriel-adorf-portfolio
 Gabriel Adorf's personal website
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/zifanyaofr/c0b34ee7-1de7-4248-aeb8-3cd0e07192ca/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.